### PR TITLE
Do not show fail/error codes after achieving success.

### DIFF
--- a/packages/react-app/src/components/activation/activationSlice.ts
+++ b/packages/react-app/src/components/activation/activationSlice.ts
@@ -32,7 +32,7 @@ import { requestActivation } from './activationAPI'
 export interface ActivationState {
   status: `Ready` | `Loading` | `Failed` | `Error` | `Activated`
   message?: string
-  code?: string
+  code?: string | undefined
 }
 
 const initialState: ActivationState = {
@@ -82,6 +82,7 @@ export const activationSlice = createSlice({
           case `success`:
             state.status = `Activated`
             state.message = `Activation successful. Please sign in.`
+            state.code = undefined
             break
           default:
             state = initialState

--- a/packages/react-app/src/components/authentication/authenticationSlice.ts
+++ b/packages/react-app/src/components/authentication/authenticationSlice.ts
@@ -32,7 +32,7 @@ import { requestAuthentication } from './authenticationAPI'
 export interface AuthenticationState {
   status: `Required` | `Loading` | `Failed` | `Error` | `Authenticated`
   message?: string
-  code?: string
+  code?: string | undefined
   token?: string | null
 }
 
@@ -92,6 +92,7 @@ export const authenticationSlice = createSlice({
               state.status = `Failed`
               state.message = `Authentication failure. No token received. ${action?.payload?.message}`
             }
+            state.code = undefined
             break
           default:
             state = initialState

--- a/packages/react-app/src/components/profile/profileSlice.ts
+++ b/packages/react-app/src/components/profile/profileSlice.ts
@@ -33,7 +33,7 @@ import { requestProfile } from './profileAPI'
 export interface ProfileState {
   status: `Ready` | `Loading` | `Failed` | `Error` | `Success`
   message?: string
-  code?: string
+  code?: string | undefined
   user?: UserDto
 }
 
@@ -84,7 +84,8 @@ export const profileSlice = createSlice({
           case `success`:
             state.status = `Success`
             state.message = `Profile loading successful.`
-            state.user = action.payload.data.user
+            state.code = undefined
+            state.user = action?.payload?.data?.user
             break
           default:
             state = initialState

--- a/packages/react-app/src/components/registration/registrationSlice.ts
+++ b/packages/react-app/src/components/registration/registrationSlice.ts
@@ -32,7 +32,7 @@ import { requestRegistration } from './registrationAPI'
 export interface RegistrationState {
   status: `Ready` | `Loading` | `Failed` | `Error` | `Registered`
   message?: string
-  code?: string
+  code?: string | undefined
 }
 
 const initialState: RegistrationState = {
@@ -82,6 +82,7 @@ export const registrationSlice = createSlice({
           case `success`:
             state.status = `Registered`
             state.message = `Registration successful. Please follow the new user activation link that was just sent to your email address, and then sign in.`
+            state.code = undefined
             break
           default:
             state = initialState


### PR DESCRIPTION
In the react slice files, upon success, set fail/error code to undefined.

Fixes #108 
